### PR TITLE
リロードするとjsonファイルが読み込めないバグを修正

### DIFF
--- a/app/webroot/js/data.js
+++ b/app/webroot/js/data.js
@@ -32,7 +32,10 @@ var poster 			= [],
 
 
 var url= window.location.href;
+// http://localhost/hogehoge#nekoからhogehoge#nekoを取得
 var event_str = url.substring(url.lastIndexOf('/')+1, url.length);
+// hogehoge#nekoからhogehogeを取得
+event_str = event_str.split("#")[0];
 var posMAppDataURL = "../../json/"+event_str+".json";
 var posMAppDataVersionURL = "../../json/"+event_str+"_version.json";
 var event_vote_app = null;

--- a/app/webroot/json/ptp4kwVB_version.json
+++ b/app/webroot/json/ptp4kwVB_version.json
@@ -1,3 +1,3 @@
 {
-  "version" : 1.05
+  "version" : 1.06
 }


### PR DESCRIPTION
過去の遺産のバグを修正
http://localhost/hoge#top
と#topがついた状態でリロードするとPosMAppのjsonデータが取得できなかった。
hoge#top.jsonでxhrしてた。。。。やめてくれよ。。。
