### PR TITLE
Fix/readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /tags
 *.mo
 /app/webroot/csv/*_*_*_*.csv
-/app/webroot/json/
+/app/webroot/json/*.json
 
 # IDE and editor specific files #
 #################################

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ cp core.php.default core.php
 
 ### Step.7 databaseファイルの複製
 ```
-cd ../Config/
 cp database.php.default database.php
 ```
 


### PR DESCRIPTION
今.gitignoreでjsonフォルダが作られないけど、環境作るときにjsonフォルダを自動的にプログラムが作ってくれなかった。jsonフォルダが作成されないとPosMAppがちゃんと動かない。
もしかしたら、jsonフォルダの作成の手順も書くことになるのかなって思った（自分だけが発生した減少かも）。ユーザーの手間減らしたほうがいいと思うのでgitignoreも変更します。