### PR TITLE
Macアドレスの表記を:を加え，正しく直した

### DIFF
--- a/app/Controller/VotesController.php
+++ b/app/Controller/VotesController.php
@@ -135,7 +135,7 @@ class VotesController extends AppController {
  	 */
 	private function getMacAddr($filename){
 		$tmp = explode("_", $filename);
-		return $tmp[2];
+		return wordwrap($tmp[2], 2, ":", true);
 	}
 
  	/*


### PR DESCRIPTION
VoteのページのBallot Machine IDがしっかり':'つかって表記されているようになった