### PR TITLE
Fix/schedule

### DIFF
--- a/app/Controller/SchedulesController.php
+++ b/app/Controller/SchedulesController.php
@@ -182,13 +182,26 @@ class SchedulesController extends AppController {
 	// 文字列を糞数で返す(ex. 12:30 -> 750)
 	public function _strToMin($time){
 		$timeStr = split(":", $time);
-		// 時間が間違い
-		if((string)$timeStr[0] !== (string)(Int)$timeStr[0] || (string)$timeStr[1] !== (string)(Int)$timeStr[1]){
-			if($timeStr[1] != "00" && $timeStr != "0"){
-				$this->error .= "Incorrect time value. <br>";
-				$this->check = false;
-			}
+		// 型が違う
+		if(count($timeStr) !== 2){
+			$this->error .= "Incorrect time value. <br>";
+			$this->check = false;
 		}
+
+		// 時のチェック
+		if(!preg_match("/^([1-9]|1[0-9]|2[0-4])$/", $timeStr[0])){
+			var_dump($timeStr[0]);
+			echo "aaaaaaaaaaaaaaaaaaa";
+			$this->error .= "Incorrect time(Hour) value. <br>";
+			$this->check = false;
+		}
+
+		// 分のチェック
+		if(!preg_match("/^[0-5][0-9]$/", $timeStr[1])){
+			$this->error .= "Incorrect time(Minute) value. <br>";
+			$this->check = false;
+		}
+		
 		$t = (Int)$timeStr[0];
 		$m = (Int)$timeStr[1];
 		if(count($timeStr) != 2 || $t < 0 || 24 <  $t || $m < 0 || 60 <  $m){

--- a/app/Controller/SchedulesController.php
+++ b/app/Controller/SchedulesController.php
@@ -191,7 +191,6 @@ class SchedulesController extends AppController {
 		// 時のチェック
 		if(!preg_match("/^([1-9]|1[0-9]|2[0-4])$/", $timeStr[0])){
 			var_dump($timeStr[0]);
-			echo "aaaaaaaaaaaaaaaaaaa";
 			$this->error .= "Incorrect time(Hour) value. <br>";
 			$this->check = false;
 		}
@@ -201,7 +200,7 @@ class SchedulesController extends AppController {
 			$this->error .= "Incorrect time(Minute) value. <br>";
 			$this->check = false;
 		}
-		
+
 		$t = (Int)$timeStr[0];
 		$m = (Int)$timeStr[1];
 		if(count($timeStr) != 2 || $t < 0 || 24 <  $t || $m < 0 || 60 <  $m){

--- a/app/Controller/SchedulesController.php
+++ b/app/Controller/SchedulesController.php
@@ -190,7 +190,6 @@ class SchedulesController extends AppController {
 
 		// 時のチェック
 		if(!preg_match("/^([1-9]|1[0-9]|2[0-4])$/", $timeStr[0])){
-			var_dump($timeStr[0]);
 			$this->error .= "Incorrect time(Hour) value. <br>";
 			$this->check = false;
 		}


### PR DESCRIPTION
xx:x5でも動くようになった．

とりあえず，入力の時間(12:54や14:83)に対して正しいかどうかの判定が出来ればいいので，
正規表現で対応

```
// 時
if(!preg_match("/^([1-9]|1[0-9]|2[0-4])$/", $timeStr[0])){
	$this->error .= "Incorrect time(Hour) value. <br>";
	$this->check = false;
}
```
は，時[h]が1~24ではない場合はエラーとする．

```
// 分のチェック
if(!preg_match("/^[0-5][0-9]$/", $timeStr[1])){
	$this->error .= "Incorrect time(Minute) value. <br>";
	$this->check = false;
}
```
これに関しては，分が00~59ではない場合はエラーとしている．

これで時間が正しいことは言えるでしょう・・・

```
if(count($timeStr) != 2 || $t < 0 || 24 <  $t || $m < 0 || 60 <  $m){
	$this->error .= "Incorrect time value. <br>";
	$this->check = false;
}
```
そうすると最後のこのコードいらない気がしてきた．