### PR TITLE
votepageを表示するたびにリストを再生成しないように

### DIFF
--- a/app/View/PosMapps/index.ctp
+++ b/app/View/PosMapps/index.ctp
@@ -66,7 +66,7 @@
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/count_checked.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/create_bookmark_list.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/create_list.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/encoding.js"></script>
+<!--	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/encoding.js"></script> -->
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/go_back.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/go_toppage.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/jquery.searcher.js"></script>
@@ -618,7 +618,7 @@
 
 
 <script>
-    $('#votePage').on('pageshow', function(e, d) {
+    $(document).ready(function() {
 		create_list();
     });
 </script>

--- a/app/View/PosMapps/index.ctp
+++ b/app/View/PosMapps/index.ctp
@@ -79,24 +79,7 @@
 	<scirpt type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/print_yourid.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/jquery.quicksearch.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/print_dayList.js"></script>
-
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/grid.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/version.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/detector.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/formatinf.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/errorlevel.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/bitmat.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/datablock.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/qrcode.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/bmparser.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/datamask.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/rsdecoder.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/gf256poly.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/gf256.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/decoder.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/findpat.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/alignpat.js"></script>
-	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>jsqrcode-master/src/databr.js"></script>
+	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/show_all_list.js"></script>
 
 <!-- ローディング画面 -->
 <div id="loading">
@@ -503,7 +486,7 @@
 			-->
 			<div data-role="header" data-theme="b" class="step-two"><p>候補者を下記から選択してください。</p></div>
 			<div data-role="controlgroup" data-type="horizontal">
-				<button class="c-list print-vote-btn ui-btn-active" onclick="create_list()">全件表示</button>
+				<button class="c-list print-vote-btn ui-btn-active" onclick="show_all_list()">全件表示</button>
 				<button class="b-list print-vote-btn" onclick="create_bookmark_list()">ブックマークリスト</button>
 			</div>
 			<!-- 日付ごとにボタンを表示．タブがいいけど謎バグでできなかった -->
@@ -594,7 +577,7 @@
 		str +=d.getFullYear()+'年'; //获取当前年份
 		str +=d.getMonth()+1+'月'; //获取当前月份（0——11）
 		str +=d.getDate()+'日';
-		voteDay2 = d.getDate();console.log(voteDay2);
+		voteDay2 = d.getDate();
 		str +=d.getHours()+'時';
 		str +=d.getMinutes()+'分';
 		str +=d.getSeconds()+'秒';

--- a/app/webroot/js/postermap-function.js
+++ b/app/webroot/js/postermap-function.js
@@ -66,7 +66,7 @@ $.fn.closeBasicInfo = function() {
 		unselectPoster();
 		showPosterIcons();
 		//resetAllIcons();
-	});	
+	});
 };
 
 // ラベルを変更する
@@ -88,7 +88,7 @@ $.fn.touchBookmark = function() {
 		var presenid = sessionStorage.getItem("presenid");
 		var bookmarkIcon = document.getElementById("bookmarkbutton");
 		touchBookmarkFun(presenid, bookmarkIcon);
-	});	
+	});
 };
 
 // ブックマークスターを大きくする
@@ -208,13 +208,13 @@ function changeLabel(column) {
 			if (str.length > labelmax) {
 				str = str.substring(0, labelmax) + "...";
 			}
-			
+
 			// テスト中ならばラベルの一覧に追加していく
 			setLabel(i, str);
 			// labels[i - 1] = str;
 		}
 		return labels;
-	} 
+	}
 }
 
 
@@ -352,8 +352,8 @@ function changeBasicInfoPanel(flag) {
 
 	var basicinfo = document.getElementById("basicinfo");
 
-	basicinfo.innerHTML = 
-		// "No. " 
+	basicinfo.innerHTML =
+		// "No. "
 		// + sessionStorage.getItem("posterid")+
 		 " ["
 		+ sessionStorage.getItem("presenid")
@@ -418,7 +418,7 @@ function emphasisSearchedPosters(posterids) {
 	});
 
 	showPosterIcons();
-	
+
 }
 
 
@@ -459,8 +459,8 @@ function selectPoster(posterid) {
 // 強調表示を解除する
 function unselectPoster() {
 	for (var i = 1; i <= ptotal; i++) {
-		if (pflag[i] === "t") { 
-			pflag[i] = "d"; 
+		if (pflag[i] === "t") {
+			pflag[i] = "d";
 		} else if (pflag[i] === "e") {
 			pflag[i] = "s";
 		}
@@ -526,7 +526,7 @@ function touchBookmarkFun(presenid, bookmarkIcon){
 	var bookmarkArr = getBookmarks();
 	// posteridに該当するポスターがブックマークリストに存在しているか確認用
 	var location = bookmarkArr.indexOf(presenid);
-
+console.log(presenid);
 	var starstatus;
 	if (location !== -1) {
 		// ある場合
@@ -593,7 +593,7 @@ function getBookmarks() {
 // TODO: jQueryを使うとbindされない原因をつきとめてjQueryに戻す
 function searchChanged(bar) {
 	if (bar.value.trim() !== "" && bar.value !== null) {
-		
+
 		// 検索し、強調表示する
 		console.log("search");
 		saveLog("search", {keyword:bar.value});
@@ -672,7 +672,7 @@ function searchAll(word) {
 
 	emphasisSearchedPosters(posterids);
 
-	document.getElementById("searchResult").innerHTML = 
+	document.getElementById("searchResult").innerHTML =
 		'<span id="searchResultText" class="ui-li-count" style="right:initial">'+posterids.length + "件</span>";
 
 	return pflag;

--- a/app/webroot/js/presenlist-function.js
+++ b/app/webroot/js/presenlist-function.js
@@ -244,6 +244,9 @@ $.fn.listchangebookmark = function() {
 		localStorage.setItem("bookmarks", bookmarks);
 
 		$("#bookmarkList").showBookmarkList();
+
+		//posvoteのブックマークアイコンの操作
+		$('#bookmark-'+presenid).toggle();
 	});
 };
 

--- a/app/webroot/js/vote_js/create_list.js
+++ b/app/webroot/js/vote_js/create_list.js
@@ -1,5 +1,8 @@
 function create_list() {
     var checkboxContents = "";
+    var poster_data = JSON.parse(localStorage.getItem("poster"));
+    var presen_data = JSON.parse(localStorage.getItem("presen"));
+    var author_data = JSON.parse(localStorage.getItem("author"));
     var ID, NAME, TITLE, DATE;
     var vote_data = [];
     var correct_json_flag = 0;
@@ -38,18 +41,18 @@ function create_list() {
         author[{"presenid","title","abstract","bookmark"}]
     */
     //jsonから候補者リストの配列を作成
-    $.each(poster, function(i) {
-        $.each (presen, function(j) {
-            if (poster[i].presenid === presen[j].presenid) {
-                ID = presen[j].presenid;
-                TITLE = presen[j].title;
-                DATE = poster[i].date;
+    $.each(poster_data, function(i) {
+        $.each (presen_data, function(j) {
+            if (poster_data[i].presenid === presen_data[j].presenid) {
+                ID = presen_data[j].presenid;
+                TITLE = presen_data[j].title;
+                DATE = poster_data[i].date;
                 return true;
             }
         });
-        $.each (author, function(k) {
-            if (poster[i].presenid === author[k].presenid && author[k].first === "1") {
-                NAME = author[k].name;
+        $.each (author_data, function(k) {
+            if (poster_data[i].presenid === author_data[k].presenid && author_data[k].first === "1") {
+                NAME = author_data[k].name;
                 return true;
             }
         });
@@ -78,14 +81,8 @@ function create_list() {
         checkboxContents += 'data-theme="c" id="jsform_checkbox'  + i + '" name="contender'+(i+1)+'"'+' data-candidate-id="'+vote_data[i].id+'" data-candidate-title="'+vote_data[i].title+'" data-candidate-name="'+vote_data[i].name+'"/>'
         checkboxContents += '<label for="jsform_checkbox' + i +'">';
         checkboxContents += '<div style="font-weight:normal">' + vote_data[i].id + ' (day'+vote_data[i].date+')</div>';
+        checkboxContents += '<span id=bookmark-'+vote_data[i].id+' style="display:none;">★ </span>';
         checkboxContents += '<strong>';
-        if (bookmark_list != null) {
-            for (var j=0; j<bookmark_list.length; j++) {
-                if (vote_data[i].id === bookmark_list[j]) {
-                    checkboxContents += '★ ';
-                }
-            }
-        }
         checkboxContents += vote_data[i].title;
         checkboxContents += '</strong><hr>';
         checkboxContents += '<div class="authors-on-list" style="text-align:right">' + vote_data[i].name + '</div></label></li></div>';

--- a/app/webroot/js/vote_js/show_all_list.js
+++ b/app/webroot/js/vote_js/show_all_list.js
@@ -1,0 +1,14 @@
+function show_all_list() {
+
+    $(".print-vote-btn").removeClass("ui-btn-active");
+    $(".c-list").addClass("ui-btn-active");
+    $('#my_checkbox').show();
+    $('#my_bookmark').hide();
+    $('#my_daylist').hide();
+
+    //全件表示
+    console.log('all-list');
+    $(".candidate-item").each(function() {
+        $(this).show();
+    });
+}


### PR DESCRIPTION
git checkout -b fix-all-list remotes/origin/fix-all-list

votePageを押すと毎回全件表示を行って，リストを再生成していた．
ポスターが少ない場合は問題ないが，ポスター数が多くなるとかなり重くなるため修正．