### PR TITLE
次の日の投票になったときにチェックボックスと候補者をクリアする

### DIFF
--- a/app/View/PosMapps/index.ctp
+++ b/app/View/PosMapps/index.ctp
@@ -560,7 +560,7 @@
 	<div id="confirm_candidates_voted" class="candidates_table" style="margin:5px auto"></div>
 	<div id="confirm_qrcode" align="center"></div>
 	<fieldset class="ui-grid-a">
-		<button data-icon="flat-cross" data-theme="a" onclick="go_toppage()">ホームに戻す</button>
+		<button data-icon="flat-cross" data-theme="a" onclick="go_toppage()">ホームに戻る</button>
 	</fieldset>
 </div>
 

--- a/app/View/PosMapps/index.ctp
+++ b/app/View/PosMapps/index.ctp
@@ -80,6 +80,7 @@
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/jquery.quicksearch.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/print_dayList.js"></script>
 	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/show_all_list.js"></script>
+	<script type="text/javascript" src="<?php echo $this->Html->webroot;?>js/vote_js/clear_candidate_data.js"></script>
 
 <!-- ローディング画面 -->
 <div id="loading">

--- a/app/webroot/js/toppage-function.js
+++ b/app/webroot/js/toppage-function.js
@@ -51,7 +51,10 @@ $.fn.goToVotePage = function(ev) {
 		if (already_voted === 1 && voteDay2 === voteDay) {
 	    	changePage("#AlreadyVotedPage");
 	  	}
-		else {
+		else if (already_voted === 1 && voteDay2 !== voteDay){
+			console.log("clear");
+			already_voted = 0;
+			clear_candidate_data();
 	    	changePage(nextPage);
 	    }
     });

--- a/app/webroot/js/toppage-function.js
+++ b/app/webroot/js/toppage-function.js
@@ -39,8 +39,8 @@ $.fn.goToTopPage = function(ev) {
 $.fn.goToVotePage = function(ev) {
 	var nextPage = "#votePage";
 	$(this).on(ev, function() {
-		console.log(voteDay);
-		console.log(voteDay2);
+		console.log('voteday='+voteDay);
+		console.log('voteday2='+voteDay2);
 		if (voter_param_flag === 0) {
 			changePage(nextPage);
 		}

--- a/app/webroot/js/vote_js/clear_candidate_data.js
+++ b/app/webroot/js/vote_js/clear_candidate_data.js
@@ -1,0 +1,21 @@
+function clear_candidate_data() {
+    /*
+        Candidate_ID = {contender0 : A-1, contender1: A-2, contender2: A-3};
+    */
+    var candidate_id = JSON.parse(localStorage.getItem('Candidate_ID'));
+
+    //checkされてるものをクリアする
+    for (key in candidate_id) {
+        var tmp, tmp_id;
+        tmp = parseInt(key.split('contender')[1])-1;
+        tmp_id = "#jsform_checkbox"+ tmp;
+        $(tmp_id).prop("checked", false);
+    }
+
+    //リストの更新
+    $('#my_checkbox').trigger("create");
+
+    // チェックされた投票者をクリア
+    localStorage.removeItem('Candidate_ID')
+
+}

--- a/app/webroot/js/vote_js/clear_candidate_data.js
+++ b/app/webroot/js/vote_js/clear_candidate_data.js
@@ -16,6 +16,7 @@ function clear_candidate_data() {
     $('#my_checkbox').trigger("create");
 
     // チェックされた投票者をクリア
+    CandidateID = {};
     localStorage.removeItem('Candidate_ID')
 
 }

--- a/app/webroot/js/vote_js/create_list.js
+++ b/app/webroot/js/vote_js/create_list.js
@@ -3,6 +3,7 @@ function create_list() {
     var poster_data = JSON.parse(localStorage.getItem("poster"));
     var presen_data = JSON.parse(localStorage.getItem("presen"));
     var author_data = JSON.parse(localStorage.getItem("author"));
+    var bookmark_data = localStorage.getItem("bookmarks");
     var ID, NAME, TITLE, DATE;
     var vote_data = [];
     var correct_json_flag = 0;
@@ -57,7 +58,6 @@ function create_list() {
             }
         });
         vote_data[i] = { 'id' : ID, 'title' : TITLE, 'name' : NAME, 'date' : DATE };
-        console.log(vote_data[i].id+','+vote_data[i].title+','+vote_data[i].name+','+vote_data[i].date);
         count_list = i;
     });
 
@@ -90,6 +90,12 @@ function create_list() {
     checkboxContents += "</div>";
 
     $("#my_checkbox").empty().append(checkboxContents).trigger("create");
+
+    //bookmarkが存在するならば
+    for (var i=0; i < bookmark_data.length; i++) {
+        bookmark_data = bookmark_data.split(',');
+        $('#bookmark-'+bookmark_data[i]).show();
+    }
 
     //AND検索できるようにするやつ
     var qs = $("input#searchlist").quicksearch("ul#listdata li");

--- a/app/webroot/js/vote_js/go_toppage.js
+++ b/app/webroot/js/vote_js/go_toppage.js
@@ -3,6 +3,6 @@ function go_toppage(){
         changeHash: true
     });
 
-      already_voted = 1;
+    already_voted = 1;
     voter_param_flag = 2;
 }


### PR DESCRIPTION
git checkout -b fix-clearStorage-nextday remotes/origin/fix-clearStorage-nextday

例）１日目の投票を行ったあと、２日目の投票時に１日目の投票データがチェックボックスに残っててチェックボックスを外す作業が面倒になるので、改善。

確認方法
１日目を投票する。
日付をプラス１する（実時間でもPC内時間でも可）
２日目でチェックボックスがクリアされていることが確認できる。